### PR TITLE
[codex] Add shared playback tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Shared checks
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run shared checks
+        run: ./gradlew :shared:check --console=plain --stacktrace
+
+      - name: Compile Android shared target
+        run: ./gradlew :shared:compileAndroidMain --console=plain --stacktrace

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -44,6 +44,10 @@ kotlin {
             implementation(compose.runtime)
         }
 
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+
         androidMain.dependencies {
             implementation(libs.kotlinx.coroutines.guava)
 

--- a/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.android.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.guava.asDeferred
-import kotlinx.coroutines.launch
 
 internal class PlatformMediaPlaybackController(
     private val context: Context,
@@ -32,6 +31,12 @@ internal class PlatformMediaPlaybackController(
     private val scope =
         CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
+    private val commandController = ScopedMediaPlaybackCommandController(
+        targetProvider = { AndroidMediaPlaybackCommandTarget(activeControllerDeferred.await()) },
+        scope = scope,
+        onRelease = { scope.cancel() },
+    )
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private val activeControllerDeferred: Deferred<MediaController>
         get() {
@@ -45,66 +50,107 @@ internal class PlatformMediaPlaybackController(
             return controllerDeferred
         }
 
-    override fun seekTo(positionMs: Long) = executeAfterPrepare { controller ->
+    override fun seekTo(positionMs: Long) = commandController.seekTo(positionMs)
+
+    override fun setRepeatMode(repeatMode: RepeatMode) = commandController.setRepeatMode(repeatMode)
+
+    override fun setShuffleMode(isOn: Boolean) = commandController.setShuffleMode(isOn)
+
+    override fun previous() = commandController.previous()
+
+    override fun next() = commandController.next()
+
+    override fun play() = commandController.play()
+
+    override fun pause() = commandController.pause()
+
+    override fun moveMediaItem(currentIndex: Int, newIndex: Int) =
+        commandController.moveMediaItem(currentIndex, newIndex)
+
+    override fun skipTo(musicIndex: Int) = commandController.skipTo(musicIndex)
+
+    override fun setSpeed(speed: Float) = commandController.setSpeed(speed)
+
+    override fun prepare(musics: List<Music>, index: Int, positionMs: Long) =
+        commandController.prepare(musics, index, positionMs)
+
+    override fun playMusics(musics: List<Music>, startIndex: Int) =
+        commandController.playMusics(musics, startIndex)
+
+    override fun stop() = commandController.stop()
+
+    override fun appendMusics(musics: List<Music>) = commandController.appendMusics(musics)
+
+    override fun removeMusics(vararg musicId: String) = commandController.removeMusics(*musicId)
+
+    override fun replaceMusic(index: Int, music: Music) = commandController.replaceMusic(index, music)
+
+    override fun release() = commandController.release()
+
+    override fun setMuted(muted: Boolean, androidFlags: Int) =
+        commandController.setMuted(muted, androidFlags)
+
+    override fun setVolume(volume: Float, androidFlags: Int) =
+        commandController.setVolume(volume, androidFlags)
+}
+
+private class AndroidMediaPlaybackCommandTarget(
+    private val controller: MediaController,
+) : MediaPlaybackCommandTarget {
+    override suspend fun seekTo(positionMs: Long) {
         controller.seekTo(positionMs)
     }
 
-    override fun setRepeatMode(repeatMode: RepeatMode) = executeAfterPrepare { controller ->
+    override suspend fun setRepeatMode(repeatMode: RepeatMode) {
         controller.setRepeatMode(repeatMode.value)
     }
 
-    override fun setShuffleMode(isOn: Boolean) = executeAfterPrepare { controller ->
+    override suspend fun setShuffleMode(isOn: Boolean) {
         controller.setShuffleModeEnabled(isOn)
     }
 
-    override fun previous() = executeAfterPrepare { controller ->
+    override suspend fun previous() {
         controller.seekToPrevious()
     }
 
-    override fun next() = executeAfterPrepare { controller ->
+    override suspend fun next() {
         controller.seekToNext()
     }
 
-    override fun play() = executeAfterPrepare { controller ->
+    override suspend fun play() {
         controller.play()
     }
 
-    override fun pause() = executeAfterPrepare { controller ->
+    override suspend fun pause() {
         controller.pause()
     }
 
-    override fun moveMediaItem(currentIndex: Int, newIndex: Int) = executeAfterPrepare { controller ->
+    override suspend fun moveMediaItem(currentIndex: Int, newIndex: Int) {
         controller.moveMediaItem(currentIndex, newIndex)
     }
 
-    override fun skipTo(musicIndex: Int) = executeAfterPrepare { controller ->
+    override suspend fun skipTo(musicIndex: Int) {
         controller.seekToDefaultPosition(musicIndex)
     }
 
-    override fun setSpeed(speed: Float) = executeAfterPrepare { controller ->
+    override suspend fun setSpeed(speed: Float) {
         controller.setPlaybackSpeed(speed)
     }
 
-    override fun prepare(musics: List<Music>, index: Int, positionMs: Long) = executeAfterPrepare { controller ->
+    override suspend fun prepare(musics: List<Music>, index: Int, positionMs: Long) {
         controller.setMediaItems(musics.map { it.asMediaItem() }, index, positionMs)
         controller.prepare()
     }
 
-    override fun playMusics(musics: List<Music>, startIndex: Int) = executeAfterPrepare { controller ->
-        prepare(musics, startIndex, 0)
-        controller.play()
-    }
-
-    override fun stop() = executeAfterPrepare { controller ->
+    override suspend fun stop() {
         controller.stop()
-        controller.release()
     }
 
-    override fun appendMusics(musics: List<Music>) = executeAfterPrepare { controller ->
+    override suspend fun appendMusics(musics: List<Music>) {
         controller.addMediaItems(musics.map { it.asMediaItem() })
     }
 
-    override fun removeMusics(vararg musicId: String) = executeAfterPrepare { controller ->
+    override suspend fun removeMusics(vararg musicId: String) {
         musicId.forEach { id ->
             controller.mediaItems.find { it.mediaId == id }?.let { mediaItem ->
                 controller.getMediaItemIndex(mediaItem)?.let { index ->
@@ -114,34 +160,28 @@ internal class PlatformMediaPlaybackController(
         }
     }
 
-    override fun replaceMusic(index: Int, music: Music) = executeAfterPrepare { controller ->
+    override suspend fun replaceMusic(index: Int, music: Music) {
         controller.replaceMediaItem(index, music.asMediaItem())
     }
 
-    override fun release() = executeAfterPrepare { controller ->
-        controller.stop()
-        controller.clearMediaItems()
-        controller.release()
-        scope.cancel()
-    }
-
-    override fun setMuted(muted: Boolean, androidFlags: Int) = executeAfterPrepare { controller ->
+    override suspend fun setMuted(muted: Boolean, androidFlags: Int) {
         controller.setDeviceMuted(muted, androidFlags)
     }
 
-    override fun setVolume(volume: Float, androidFlags: Int) = executeAfterPrepare { controller ->
-        println(controller.deviceInfo.minVolume)
-        val minVolume = controller.deviceInfo.minVolume
-        val maxVolume = controller.deviceInfo.maxVolume
-        val scaledVolume = minVolume + (volume * (maxVolume - minVolume)).toInt()
-        val boundedVolume = scaledVolume.coerceIn(minVolume, maxVolume)
+    override suspend fun setVolume(volume: Float, androidFlags: Int) {
+        val boundedVolume = scaleDeviceVolume(
+            volume = volume,
+            minVolume = controller.deviceInfo.minVolume,
+            maxVolume = controller.deviceInfo.maxVolume,
+        )
         controller.setDeviceVolume(boundedVolume, androidFlags)
     }
 
-    private inline fun executeAfterPrepare(crossinline action: suspend (MediaController) -> Unit) {
-        scope.launch {
-            val controller = activeControllerDeferred.await()
-            action(controller)
-        }
+    override suspend fun clearMediaItems() {
+        controller.clearMediaItems()
+    }
+
+    override suspend fun release() {
+        controller.release()
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/DeviceVolumeScaler.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/DeviceVolumeScaler.kt
@@ -1,0 +1,10 @@
+package io.github.moonggae.kmedia.controller
+
+internal fun scaleDeviceVolume(
+    volume: Float,
+    minVolume: Int,
+    maxVolume: Int,
+): Int {
+    val scaledVolume = minVolume + (volume * (maxVolume - minVolume)).toInt()
+    return scaledVolume.coerceIn(minVolume, maxVolume)
+}

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/MediaPlaybackCommandTarget.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/MediaPlaybackCommandTarget.kt
@@ -1,0 +1,44 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.Music
+import io.github.moonggae.kmedia.model.RepeatMode
+
+internal interface MediaPlaybackCommandTarget {
+    suspend fun seekTo(positionMs: Long)
+
+    suspend fun setRepeatMode(repeatMode: RepeatMode)
+
+    suspend fun setShuffleMode(isOn: Boolean)
+
+    suspend fun previous()
+
+    suspend fun next()
+
+    suspend fun play()
+
+    suspend fun pause()
+
+    suspend fun moveMediaItem(currentIndex: Int, newIndex: Int)
+
+    suspend fun skipTo(musicIndex: Int)
+
+    suspend fun setSpeed(speed: Float)
+
+    suspend fun prepare(musics: List<Music>, index: Int, positionMs: Long)
+
+    suspend fun stop()
+
+    suspend fun appendMusics(musics: List<Music>)
+
+    suspend fun removeMusics(vararg musicId: String)
+
+    suspend fun replaceMusic(index: Int, music: Music)
+
+    suspend fun setMuted(muted: Boolean, androidFlags: Int)
+
+    suspend fun setVolume(volume: Float, androidFlags: Int)
+
+    suspend fun clearMediaItems()
+
+    suspend fun release()
+}

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/PlaylistRemovalResult.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/PlaylistRemovalResult.kt
@@ -1,0 +1,17 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.Music
+
+internal sealed interface PlaylistRemovalResult {
+    data object NotFound : PlaylistRemovalResult
+
+    data class RemovedNonCurrent(
+        val currentMusic: Music,
+    ) : PlaylistRemovalResult
+
+    data class RemovedCurrent(
+        val replacementMusic: Music,
+    ) : PlaylistRemovalResult
+
+    data object PlaylistBecameEmpty : PlaylistRemovalResult
+}

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/PlaylistState.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/PlaylistState.kt
@@ -1,0 +1,155 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.Music
+import io.github.moonggae.kmedia.model.RepeatMode
+import io.github.moonggae.kmedia.util.reorder
+
+internal class PlaylistState(
+    private val shuffleOrder: ShuffleOrder = ShuffleOrder(),
+) {
+    private val playlist = mutableListOf<Music>()
+
+    var currentIndex = 0
+        private set
+
+    var repeatMode = RepeatMode.REPEAT_MODE_OFF
+        private set
+
+    var isShuffleOn = false
+        private set
+
+    fun getCurrentMusic(): Music? = playlist.getOrNull(currentIndex)
+
+    fun getPlaylist(): List<Music> = playlist.toList()
+
+    fun updatePlaylist(musics: List<Music>, startIndex: Int) {
+        playlist.clear()
+        playlist.addAll(musics)
+        currentIndex = if (playlist.isEmpty()) {
+            0
+        } else {
+            startIndex.coerceIn(0, playlist.lastIndex)
+        }
+
+        if (isShuffleOn) {
+            shuffleOrder.updateShuffleIndices(currentIndex, playlist.size)
+        }
+    }
+
+    fun appendMusics(musics: List<Music>) {
+        val startIndex = playlist.size
+        val newMusics = musics - playlist.toSet()
+        playlist.addAll(newMusics)
+
+        if (isShuffleOn) {
+            shuffleOrder.addNewIndices(startIndex, newMusics.size)
+        }
+    }
+
+    fun removeMusic(musicId: String): PlaylistRemovalResult {
+        val removeIndex = playlist.indexOfFirst { it.id == musicId }
+        if (removeIndex < 0) return PlaylistRemovalResult.NotFound
+
+        val isRemovingCurrent = removeIndex == currentIndex
+        val replacementMusic = if (isRemovingCurrent) {
+            getReplacementForCurrentRemoval(removeIndex)
+        } else null
+
+        playlist.removeAt(removeIndex)
+
+        if (isShuffleOn) {
+            shuffleOrder.removeIndex(removeIndex)
+        }
+
+        if (playlist.isEmpty()) {
+            currentIndex = 0
+            return PlaylistRemovalResult.PlaylistBecameEmpty
+        }
+
+        if (isRemovingCurrent) {
+            currentIndex = replacementMusic
+                ?.let { playlist.indexOf(it) }
+                ?.takeIf { it >= 0 }
+                ?: currentIndex.coerceIn(0, playlist.lastIndex)
+        } else if (removeIndex < currentIndex) {
+            currentIndex--
+        }
+
+        val currentMusic = checkNotNull(getCurrentMusic())
+        return if (isRemovingCurrent) {
+            PlaylistRemovalResult.RemovedCurrent(currentMusic)
+        } else {
+            PlaylistRemovalResult.RemovedNonCurrent(currentMusic)
+        }
+    }
+
+    private fun getReplacementForCurrentRemoval(removeIndex: Int): Music? {
+        return if (isShuffleOn) {
+            val nextShuffledIndex = shuffleOrder.getNextIndex(currentIndex, repeatMode)
+                ?: shuffleOrder.getPreviousIndex(currentIndex)
+            nextShuffledIndex?.let { playlist.getOrNull(it) }
+        } else {
+            playlist.getOrNull(removeIndex + 1) ?: playlist.getOrNull(removeIndex - 1)
+        }
+    }
+
+    fun setShuffleMode(isOn: Boolean) {
+        if (this.isShuffleOn != isOn) {
+            this.isShuffleOn = isOn
+            if (isOn) {
+                shuffleOrder.updateShuffleIndices(currentIndex, playlist.size)
+            }
+        }
+    }
+
+    fun setRepeatMode(mode: RepeatMode) {
+        this.repeatMode = mode
+    }
+
+    fun moveMediaItem(fromIndex: Int, toIndex: Int) {
+        val currentMusicId = playlist[currentIndex].id
+        playlist.reorder(fromIndex, toIndex)
+        currentIndex = playlist.indexOfFirst { it.id == currentMusicId }
+    }
+
+    fun replaceMusic(index: Int, music: Music) {
+        if (index in 0..playlist.lastIndex) {
+            playlist[index] = music
+        }
+    }
+
+    fun getNextIndex(): Int? = when {
+        playlist.isEmpty() -> null
+        isShuffleOn -> shuffleOrder.getNextIndex(currentIndex, repeatMode)
+        else -> when {
+            currentIndex == playlist.lastIndex &&
+                    repeatMode == RepeatMode.REPEAT_MODE_OFF -> null
+            currentIndex == playlist.lastIndex -> 0
+            else -> currentIndex + 1
+        }
+    }
+
+    fun getPreviousIndex(): Int? = when {
+        isShuffleOn -> shuffleOrder.getPreviousIndex(currentIndex)
+        currentIndex > 0 -> currentIndex - 1
+        else -> null
+    }
+
+    fun setCurrentIndex(index: Int) {
+        if (index in 0..playlist.lastIndex) {
+            currentIndex = index
+        }
+    }
+
+    fun clear() {
+        playlist.clear()
+        currentIndex = 0
+        repeatMode = RepeatMode.REPEAT_MODE_OFF
+        isShuffleOn = false
+        shuffleOrder.clear()
+    }
+
+    fun hasNext(): Boolean = getNextIndex() != null
+
+    fun hasPrevious(): Boolean = currentIndex > 0
+}

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandController.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandController.kt
@@ -1,0 +1,99 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.Music
+import io.github.moonggae.kmedia.model.RepeatMode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal class ScopedMediaPlaybackCommandController(
+    private val targetProvider: suspend () -> MediaPlaybackCommandTarget,
+    private val scope: CoroutineScope,
+    private val onRelease: () -> Unit = {},
+) : MediaPlaybackController, MediaPlaybackControllerReleaser {
+    override fun seekTo(positionMs: Long) = execute { target ->
+        target.seekTo(positionMs)
+    }
+
+    override fun setRepeatMode(repeatMode: RepeatMode) = execute { target ->
+        target.setRepeatMode(repeatMode)
+    }
+
+    override fun setShuffleMode(isOn: Boolean) = execute { target ->
+        target.setShuffleMode(isOn)
+    }
+
+    override fun previous() = execute { target ->
+        target.previous()
+    }
+
+    override fun next() = execute { target ->
+        target.next()
+    }
+
+    override fun play() = execute { target ->
+        target.play()
+    }
+
+    override fun pause() = execute { target ->
+        target.pause()
+    }
+
+    override fun moveMediaItem(currentIndex: Int, newIndex: Int) = execute { target ->
+        target.moveMediaItem(currentIndex, newIndex)
+    }
+
+    override fun skipTo(musicIndex: Int) = execute { target ->
+        target.skipTo(musicIndex)
+    }
+
+    override fun setSpeed(speed: Float) = execute { target ->
+        target.setSpeed(speed)
+    }
+
+    override fun prepare(musics: List<Music>, index: Int, positionMs: Long) = execute { target ->
+        target.prepare(musics, index, positionMs)
+    }
+
+    override fun playMusics(musics: List<Music>, startIndex: Int) = execute { target ->
+        target.prepare(musics, startIndex, positionMs = 0)
+        target.play()
+    }
+
+    override fun stop() = execute { target ->
+        target.stop()
+        target.release()
+    }
+
+    override fun appendMusics(musics: List<Music>) = execute { target ->
+        target.appendMusics(musics)
+    }
+
+    override fun removeMusics(vararg musicId: String) = execute { target ->
+        target.removeMusics(*musicId)
+    }
+
+    override fun replaceMusic(index: Int, music: Music) = execute { target ->
+        target.replaceMusic(index, music)
+    }
+
+    override fun setMuted(muted: Boolean, androidFlags: Int) = execute { target ->
+        target.setMuted(muted, androidFlags)
+    }
+
+    override fun setVolume(volume: Float, androidFlags: Int) = execute { target ->
+        target.setVolume(volume, androidFlags)
+    }
+
+    override fun release() = execute { target ->
+        target.stop()
+        target.clearMediaItems()
+        target.release()
+        onRelease()
+    }
+
+    private inline fun execute(crossinline action: suspend (MediaPlaybackCommandTarget) -> Unit) {
+        scope.launch {
+            action(targetProvider())
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/ShuffleOrder.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/ShuffleOrder.kt
@@ -1,0 +1,62 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.RepeatMode
+import kotlin.random.Random
+
+internal class ShuffleOrder(
+    private val random: Random = Random.Default,
+) {
+    private var shuffledIndices = mutableListOf<Int>()
+
+    fun updateShuffleIndices(currentIndex: Int, totalSize: Int) {
+        if (totalSize <= 0 || currentIndex !in 0 until totalSize) {
+            shuffledIndices.clear()
+            return
+        }
+
+        val remainingIndices = (0 until totalSize)
+            .filter { it != currentIndex }
+            .toMutableList()
+        remainingIndices.shuffle(random)
+
+        shuffledIndices = mutableListOf(currentIndex).apply {
+            addAll(remainingIndices)
+        }
+    }
+
+    fun getNextIndex(currentIndex: Int, repeatMode: RepeatMode): Int? {
+        val currentShuffledIndex = shuffledIndices.indexOf(currentIndex)
+        return when {
+            currentShuffledIndex < 0 -> null
+            currentShuffledIndex == shuffledIndices.lastIndex &&
+                    repeatMode == RepeatMode.REPEAT_MODE_OFF -> null
+            currentShuffledIndex == shuffledIndices.lastIndex ->
+                shuffledIndices.firstOrNull()
+            else -> shuffledIndices.getOrNull(currentShuffledIndex + 1)
+        }
+    }
+
+    fun getPreviousIndex(currentIndex: Int): Int? {
+        val currentShuffledIndex = shuffledIndices.indexOf(currentIndex)
+        return if (currentShuffledIndex > 0) {
+            shuffledIndices[currentShuffledIndex - 1]
+        } else null
+    }
+
+    fun removeIndex(index: Int) {
+        shuffledIndices.remove(index)
+        shuffledIndices = shuffledIndices
+            .map { if (it > index) it - 1 else it }
+            .toMutableList()
+    }
+
+    fun clear() {
+        shuffledIndices.clear()
+    }
+
+    fun addNewIndices(startIndex: Int, count: Int) {
+        val newIndices = (startIndex until startIndex + count).toMutableList()
+        newIndices.shuffle(random)
+        shuffledIndices.addAll(newIndices)
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/sleep/SleepTimerController.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/sleep/SleepTimerController.kt
@@ -7,7 +7,6 @@ import io.github.moonggae.kmedia.model.PlayingStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -46,6 +45,7 @@ internal class DefaultSleepTimerController(
     private val mediaPlaybackController: MediaPlaybackController,
     private val playbackState: StateFlow<PlaybackState>,
     private val scope: CoroutineScope,
+    private val timerClock: SleepTimerClock = MonotonicSleepTimerClock,
 ) : SleepTimerController {
     private val _state = MutableStateFlow(SleepTimerState())
     override val state: StateFlow<SleepTimerState> = _state.asStateFlow()
@@ -90,10 +90,10 @@ internal class DefaultSleepTimerController(
     }
 
     private suspend fun runDurationTimer(durationMs: Long) {
-        val mark = TimeSource.Monotonic.markNow()
+        val mark = timerClock.markNow()
 
         while (currentCoroutineContext().isActive) {
-            val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+            val elapsedMs = mark.elapsedMs()
             val remainingMs = (durationMs - elapsedMs).coerceAtLeast(0L)
 
             _state.update { state ->
@@ -109,7 +109,7 @@ internal class DefaultSleepTimerController(
                 return
             }
 
-            delay(minOf(DURATION_TICK_MS, remainingMs))
+            timerClock.delay(minOf(DURATION_TICK_MS, remainingMs))
         }
     }
 
@@ -134,7 +134,7 @@ internal class DefaultSleepTimerController(
                 return
             }
 
-            delay(END_OF_TRACK_POLLING_MS)
+            timerClock.delay(END_OF_TRACK_POLLING_MS)
         }
     }
 
@@ -153,7 +153,7 @@ internal class DefaultSleepTimerController(
                     mediaPlaybackController.setVolume(nextVolume, ANDROID_VOLUME_FLAGS)
 
                     if (index < fadeSteps - 1) {
-                        delay(FADE_OUT_STEP_MS)
+                        timerClock.delay(FADE_OUT_STEP_MS)
                     }
                 }
             }
@@ -201,5 +201,28 @@ internal class DefaultSleepTimerController(
         private const val MIN_FADE_VOLUME = 0.01f
 
         private const val ANDROID_VOLUME_FLAGS = 0
+    }
+}
+
+internal interface SleepTimerClock {
+    fun markNow(): SleepTimerMark
+
+    suspend fun delay(durationMs: Long)
+}
+
+internal interface SleepTimerMark {
+    fun elapsedMs(): Long
+}
+
+private object MonotonicSleepTimerClock : SleepTimerClock {
+    override fun markNow(): SleepTimerMark {
+        val mark = TimeSource.Monotonic.markNow()
+        return object : SleepTimerMark {
+            override fun elapsedMs(): Long = mark.elapsedNow().inWholeMilliseconds
+        }
+    }
+
+    override suspend fun delay(durationMs: Long) {
+        kotlinx.coroutines.delay(durationMs)
     }
 }

--- a/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/DeviceVolumeScalerTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/DeviceVolumeScalerTest.kt
@@ -1,0 +1,19 @@
+package io.github.moonggae.kmedia.controller
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DeviceVolumeScalerTest {
+    @Test
+    fun scaleDeviceVolumeMapsNormalizedVolumeIntoDeviceRange() {
+        assertEquals(2, scaleDeviceVolume(volume = 0f, minVolume = 2, maxVolume = 12))
+        assertEquals(7, scaleDeviceVolume(volume = 0.5f, minVolume = 2, maxVolume = 12))
+        assertEquals(12, scaleDeviceVolume(volume = 1f, minVolume = 2, maxVolume = 12))
+    }
+
+    @Test
+    fun scaleDeviceVolumeCoercesOutsideNormalizedRange() {
+        assertEquals(2, scaleDeviceVolume(volume = -1f, minVolume = 2, maxVolume = 12))
+        assertEquals(12, scaleDeviceVolume(volume = 2f, minVolume = 2, maxVolume = 12))
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/PlaylistStateTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/PlaylistStateTest.kt
@@ -1,0 +1,238 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.Music
+import io.github.moonggae.kmedia.model.RepeatMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PlaylistStateTest {
+    @Test
+    fun updatePlaylistClampsStartIndexToValidItem() {
+        val playlist = PlaylistState()
+
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 99)
+
+        assertEquals(2, playlist.currentIndex)
+        assertEquals("track-2", playlist.getCurrentMusic()?.id)
+    }
+
+    @Test
+    fun nextReturnsNullAtEndWhenRepeatIsOff() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 2)
+
+        assertNull(playlist.getNextIndex())
+        assertFalse(playlist.hasNext())
+    }
+
+    @Test
+    fun nextWrapsAtEndWhenRepeatAllIsEnabled() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 2)
+        playlist.setRepeatMode(RepeatMode.REPEAT_MODE_ALL)
+
+        assertEquals(0, playlist.getNextIndex())
+        assertTrue(playlist.hasNext())
+    }
+
+    @Test
+    fun emptyPlaylistDoesNotHaveNextEvenWhenRepeatAllIsEnabled() {
+        val playlist = PlaylistState()
+        playlist.setRepeatMode(RepeatMode.REPEAT_MODE_ALL)
+
+        assertNull(playlist.getNextIndex())
+        assertFalse(playlist.hasNext())
+    }
+
+    @Test
+    fun enablingShuffleBeforeAddingFirstItemDoesNotCreateSelfNext() {
+        val playlist = PlaylistState()
+
+        playlist.setShuffleMode(true)
+        playlist.appendMusics(tracks(1))
+
+        assertNull(playlist.getNextIndex())
+        assertFalse(playlist.hasNext())
+    }
+
+    @Test
+    fun previousReturnsNullAtBeginning() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 0)
+
+        assertNull(playlist.getPreviousIndex())
+        assertFalse(playlist.hasPrevious())
+    }
+
+    @Test
+    fun appendMusicsSkipsExistingItems() {
+        val playlist = PlaylistState()
+        val existingTracks = tracks(2)
+        playlist.updatePlaylist(musics = existingTracks, startIndex = 0)
+
+        playlist.appendMusics(listOf(existingTracks[1], track("track-2")))
+
+        assertEquals(listOf("track-0", "track-1", "track-2"), playlist.ids())
+    }
+
+    @Test
+    fun movingNonCurrentItemPreservesCurrentMusic() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(4), startIndex = 1)
+
+        playlist.moveMediaItem(fromIndex = 3, toIndex = 0)
+
+        assertEquals("track-1", playlist.getCurrentMusic()?.id)
+        assertEquals(2, playlist.currentIndex)
+        assertEquals(listOf("track-3", "track-0", "track-1", "track-2"), playlist.ids())
+    }
+
+    @Test
+    fun movingCurrentItemPreservesCurrentMusicAtNewIndex() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(4), startIndex = 1)
+
+        playlist.moveMediaItem(fromIndex = 1, toIndex = 3)
+
+        assertEquals("track-1", playlist.getCurrentMusic()?.id)
+        assertEquals(3, playlist.currentIndex)
+        assertEquals(listOf("track-0", "track-2", "track-3", "track-1"), playlist.ids())
+    }
+
+    @Test
+    fun removingNonCurrentItemBeforeCurrentPreservesCurrentMusic() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(4), startIndex = 2)
+
+        val result = playlist.removeMusic("track-0")
+
+        assertIs<PlaylistRemovalResult.RemovedNonCurrent>(result)
+        assertEquals("track-2", result.currentMusic.id)
+        assertEquals("track-2", playlist.getCurrentMusic()?.id)
+        assertEquals(1, playlist.currentIndex)
+        assertEquals(listOf("track-1", "track-2", "track-3"), playlist.ids())
+    }
+
+    @Test
+    fun removingNonCurrentItemAfterCurrentPreservesCurrentMusic() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(4), startIndex = 1)
+
+        val result = playlist.removeMusic("track-3")
+
+        assertIs<PlaylistRemovalResult.RemovedNonCurrent>(result)
+        assertEquals("track-1", result.currentMusic.id)
+        assertEquals("track-1", playlist.getCurrentMusic()?.id)
+        assertEquals(1, playlist.currentIndex)
+        assertEquals(listOf("track-0", "track-1", "track-2"), playlist.ids())
+    }
+
+    @Test
+    fun removingCurrentMiddleItemSelectsNextItem() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(4), startIndex = 1)
+
+        val result = playlist.removeMusic("track-1")
+
+        assertIs<PlaylistRemovalResult.RemovedCurrent>(result)
+        assertEquals("track-2", result.replacementMusic.id)
+        assertEquals("track-2", playlist.getCurrentMusic()?.id)
+        assertEquals(1, playlist.currentIndex)
+        assertEquals(listOf("track-0", "track-2", "track-3"), playlist.ids())
+    }
+
+    @Test
+    fun removingCurrentLastItemSelectsPreviousItem() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 2)
+
+        val result = playlist.removeMusic("track-2")
+
+        assertIs<PlaylistRemovalResult.RemovedCurrent>(result)
+        assertEquals("track-1", result.replacementMusic.id)
+        assertEquals("track-1", playlist.getCurrentMusic()?.id)
+        assertEquals(1, playlist.currentIndex)
+        assertEquals(listOf("track-0", "track-1"), playlist.ids())
+    }
+
+    @Test
+    fun removingMissingItemReturnsNotFoundAndKeepsPlaylist() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 1)
+
+        val result = playlist.removeMusic("missing")
+
+        assertEquals(PlaylistRemovalResult.NotFound, result)
+        assertEquals("track-1", playlist.getCurrentMusic()?.id)
+        assertEquals(listOf("track-0", "track-1", "track-2"), playlist.ids())
+    }
+
+    @Test
+    fun removingOnlyItemReturnsPlaylistBecameEmpty() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(1), startIndex = 0)
+
+        val result = playlist.removeMusic("track-0")
+
+        assertEquals(PlaylistRemovalResult.PlaylistBecameEmpty, result)
+        assertNull(playlist.getCurrentMusic())
+        assertEquals(0, playlist.currentIndex)
+        assertTrue(playlist.getPlaylist().isEmpty())
+    }
+
+    @Test
+    fun replacingCurrentItemUpdatesCurrentMusic() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 1)
+
+        playlist.replaceMusic(index = 1, music = track("replacement"))
+
+        assertEquals("replacement", playlist.getCurrentMusic()?.id)
+        assertEquals(listOf("track-0", "replacement", "track-2"), playlist.ids())
+    }
+
+    @Test
+    fun replacingNonCurrentItemDoesNotChangeCurrentMusic() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 1)
+
+        playlist.replaceMusic(index = 2, music = track("replacement"))
+
+        assertEquals("track-1", playlist.getCurrentMusic()?.id)
+        assertEquals(listOf("track-0", "track-1", "replacement"), playlist.ids())
+    }
+
+    @Test
+    fun clearResetsPlaylistModesAndCurrentState() {
+        val playlist = PlaylistState()
+        playlist.updatePlaylist(musics = tracks(3), startIndex = 1)
+        playlist.setRepeatMode(RepeatMode.REPEAT_MODE_ALL)
+        playlist.setShuffleMode(true)
+
+        playlist.clear()
+
+        assertTrue(playlist.getPlaylist().isEmpty())
+        assertNull(playlist.getCurrentMusic())
+        assertEquals(0, playlist.currentIndex)
+        assertEquals(RepeatMode.REPEAT_MODE_OFF, playlist.repeatMode)
+        assertFalse(playlist.isShuffleOn)
+        assertFalse(playlist.hasNext())
+        assertFalse(playlist.hasPrevious())
+    }
+
+    private fun tracks(count: Int): List<Music> = List(count) { index ->
+        track("track-$index")
+    }
+
+    private fun track(id: String) = Music(
+        id = id,
+        title = id,
+        uri = "https://example.com/$id.mp3",
+    )
+
+    private fun PlaylistState.ids(): List<String> = getPlaylist().map { it.id }
+}

--- a/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandControllerTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandControllerTest.kt
@@ -1,0 +1,181 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.Music
+import io.github.moonggae.kmedia.model.RepeatMode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ScopedMediaPlaybackCommandControllerTest {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterTest
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun playMusicsPreparesPlaylistBeforePlay() {
+        val target = RecordingCommandTarget()
+        val controller = controller(target)
+        val musics = listOf(music("track-1"), music("track-2"))
+
+        controller.playMusics(musics, startIndex = 1)
+
+        assertEquals(
+            listOf(
+                "prepare(track-1,track-2,index=1,position=0)",
+                "play",
+            ),
+            target.calls,
+        )
+    }
+
+    @Test
+    fun prepareDoesNotStartPlayback() {
+        val target = RecordingCommandTarget()
+        val controller = controller(target)
+
+        controller.prepare(
+            musics = listOf(music("track-1")),
+            index = 0,
+            positionMs = 30_000L,
+        )
+
+        assertEquals(
+            listOf("prepare(track-1,index=0,position=30000)"),
+            target.calls,
+        )
+    }
+
+    @Test
+    fun stopStopsAndReleasesTarget() {
+        val target = RecordingCommandTarget()
+        val controller = controller(target)
+
+        controller.stop()
+
+        assertEquals(listOf("stop", "release"), target.calls)
+    }
+
+    @Test
+    fun releaseStopsClearsReleasesAndRunsReleaseHook() {
+        val target = RecordingCommandTarget()
+        var releaseHookCalled = false
+        val controller = ScopedMediaPlaybackCommandController(
+            targetProvider = { target },
+            scope = scope,
+            onRelease = { releaseHookCalled = true },
+        )
+
+        controller.release()
+
+        assertEquals(listOf("stop", "clearMediaItems", "release"), target.calls)
+        assertTrue(releaseHookCalled)
+    }
+
+    @Test
+    fun removeMusicsForwardsAllRequestedIds() {
+        val target = RecordingCommandTarget()
+        val controller = controller(target)
+
+        controller.removeMusics("track-1", "track-3")
+
+        assertEquals(listOf("removeMusics(track-1,track-3)"), target.calls)
+    }
+
+    private fun controller(target: RecordingCommandTarget) = ScopedMediaPlaybackCommandController(
+        targetProvider = { target },
+        scope = scope,
+    )
+
+    private fun music(id: String) = Music(
+        id = id,
+        uri = "https://example.com/$id.mp3",
+    )
+}
+
+private class RecordingCommandTarget : MediaPlaybackCommandTarget {
+    val calls = mutableListOf<String>()
+
+    override suspend fun seekTo(positionMs: Long) {
+        calls += "seekTo($positionMs)"
+    }
+
+    override suspend fun setRepeatMode(repeatMode: RepeatMode) {
+        calls += "setRepeatMode($repeatMode)"
+    }
+
+    override suspend fun setShuffleMode(isOn: Boolean) {
+        calls += "setShuffleMode($isOn)"
+    }
+
+    override suspend fun previous() {
+        calls += "previous"
+    }
+
+    override suspend fun next() {
+        calls += "next"
+    }
+
+    override suspend fun play() {
+        calls += "play"
+    }
+
+    override suspend fun pause() {
+        calls += "pause"
+    }
+
+    override suspend fun moveMediaItem(currentIndex: Int, newIndex: Int) {
+        calls += "moveMediaItem($currentIndex,$newIndex)"
+    }
+
+    override suspend fun skipTo(musicIndex: Int) {
+        calls += "skipTo($musicIndex)"
+    }
+
+    override suspend fun setSpeed(speed: Float) {
+        calls += "setSpeed($speed)"
+    }
+
+    override suspend fun prepare(musics: List<Music>, index: Int, positionMs: Long) {
+        calls += "prepare(${musics.joinToString(",") { it.id }},index=$index,position=$positionMs)"
+    }
+
+    override suspend fun stop() {
+        calls += "stop"
+    }
+
+    override suspend fun appendMusics(musics: List<Music>) {
+        calls += "appendMusics(${musics.joinToString(",") { it.id }})"
+    }
+
+    override suspend fun removeMusics(vararg musicId: String) {
+        calls += "removeMusics(${musicId.joinToString(",")})"
+    }
+
+    override suspend fun replaceMusic(index: Int, music: Music) {
+        calls += "replaceMusic($index,${music.id})"
+    }
+
+    override suspend fun setMuted(muted: Boolean, androidFlags: Int) {
+        calls += "setMuted($muted,$androidFlags)"
+    }
+
+    override suspend fun setVolume(volume: Float, androidFlags: Int) {
+        calls += "setVolume($volume,$androidFlags)"
+    }
+
+    override suspend fun clearMediaItems() {
+        calls += "clearMediaItems"
+    }
+
+    override suspend fun release() {
+        calls += "release"
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/ShuffleOrderTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/ShuffleOrderTest.kt
@@ -1,0 +1,48 @@
+package io.github.moonggae.kmedia.controller
+
+import io.github.moonggae.kmedia.model.RepeatMode
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ShuffleOrderTest {
+    @Test
+    fun shuffledOrderStartsFromCurrentIndexAndVisitsEveryOtherIndexOnce() {
+        val order = ShuffleOrder(random = Random(1))
+        val visited = mutableListOf<Int>()
+        var currentIndex = 2
+
+        order.updateShuffleIndices(currentIndex = currentIndex, totalSize = 5)
+
+        while (true) {
+            val nextIndex = order.getNextIndex(currentIndex, RepeatMode.REPEAT_MODE_OFF) ?: break
+            visited += nextIndex
+            currentIndex = nextIndex
+        }
+
+        assertEquals(setOf(0, 1, 3, 4), visited.toSet())
+        assertEquals(4, visited.size)
+        assertNull(order.getNextIndex(currentIndex, RepeatMode.REPEAT_MODE_OFF))
+        assertEquals(2, order.getNextIndex(currentIndex, RepeatMode.REPEAT_MODE_ALL))
+    }
+
+    @Test
+    fun removeIndexDropsRemovedPlaylistIndexAndShiftsHigherIndices() {
+        val order = ShuffleOrder(random = Random(2))
+        order.updateShuffleIndices(currentIndex = 1, totalSize = 4)
+
+        order.removeIndex(0)
+
+        val visited = mutableListOf<Int>()
+        var currentIndex = 0
+        while (true) {
+            val nextIndex = order.getNextIndex(currentIndex, RepeatMode.REPEAT_MODE_OFF) ?: break
+            visited += nextIndex
+            currentIndex = nextIndex
+        }
+
+        assertEquals(setOf(1, 2), visited.toSet())
+        assertEquals(2, visited.size)
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/sleep/SleepTimerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/sleep/SleepTimerControllerTest.kt
@@ -1,0 +1,295 @@
+package io.github.moonggae.kmedia.sleep
+
+import io.github.moonggae.kmedia.controller.MediaPlaybackController
+import io.github.moonggae.kmedia.model.Music
+import io.github.moonggae.kmedia.model.PlaybackState
+import io.github.moonggae.kmedia.model.PlayingStatus
+import io.github.moonggae.kmedia.model.RepeatMode
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SleepTimerControllerTest {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterTest
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun durationTimerNormalizesDurationsUnderOneSecond() {
+        val clock = ControllableSleepTimerClock()
+        val controller = controller(clock = clock)
+
+        controller.start(durationMs = 10L)
+
+        assertEquals(
+            SleepTimerState(
+                mode = SleepTimerMode.DURATION,
+                durationMs = 1_000L,
+                remainingMs = 1_000L,
+            ),
+            controller.state.value,
+        )
+    }
+
+    @Test
+    fun durationTimerPausesWhenTimeExpiresAndRestoresVolumeAfterFade() {
+        val clock = ControllableSleepTimerClock()
+        val player = RecordingMediaPlaybackController()
+        val playbackState = MutableStateFlow(
+            PlaybackState(
+                volume = 0.8f,
+                isMuted = false,
+            )
+        )
+        val controller = controller(
+            clock = clock,
+            player = player,
+            playbackState = playbackState,
+        )
+
+        controller.start(durationMs = 2_000L)
+        clock.advanceBy(1_000L)
+
+        assertEquals(1_000L, controller.state.value.remainingMs)
+
+        clock.advanceBy(1_000L)
+        clock.advanceUntilIdle()
+
+        assertEquals(1, player.pauseCalls)
+        assertEquals(0.8f, player.volumeCalls.last())
+        assertTrue(player.volumeCalls.any { it < 0.8f })
+        assertEquals(SleepTimerState(), controller.state.value)
+    }
+
+    @Test
+    fun mutedDurationTimerSkipsFadeButStillPauses() {
+        val clock = ControllableSleepTimerClock()
+        val player = RecordingMediaPlaybackController()
+        val playbackState = MutableStateFlow(
+            PlaybackState(
+                volume = 0.8f,
+                isMuted = true,
+            )
+        )
+        val controller = controller(
+            clock = clock,
+            player = player,
+            playbackState = playbackState,
+        )
+
+        controller.start(durationMs = 1_000L)
+        clock.advanceBy(1_000L)
+
+        assertEquals(1, player.pauseCalls)
+        assertTrue(player.volumeCalls.isEmpty())
+        assertEquals(SleepTimerState(), controller.state.value)
+    }
+
+    @Test
+    fun cancelPreventsPendingTimerFromPausingPlayback() {
+        val clock = ControllableSleepTimerClock()
+        val player = RecordingMediaPlaybackController()
+        val controller = controller(
+            clock = clock,
+            player = player,
+        )
+
+        controller.start(durationMs = 1_000L)
+        controller.cancel()
+        clock.advanceUntilIdle()
+
+        assertEquals(0, player.pauseCalls)
+        assertEquals(SleepTimerState(), controller.state.value)
+    }
+
+    @Test
+    fun startingNewDurationTimerCancelsPreviousTimer() {
+        val clock = ControllableSleepTimerClock()
+        val player = RecordingMediaPlaybackController()
+        val playbackState = MutableStateFlow(
+            PlaybackState(
+                volume = 0.8f,
+                isMuted = true,
+            )
+        )
+        val controller = controller(
+            clock = clock,
+            player = player,
+            playbackState = playbackState,
+        )
+
+        controller.start(durationMs = 5_000L)
+        controller.start(durationMs = 2_000L)
+        clock.advanceUntilIdle()
+
+        assertEquals(1, player.pauseCalls)
+        assertEquals(SleepTimerState(), controller.state.value)
+    }
+
+    @Test
+    fun currentTrackEndTimerPausesWhenRemainingTimeIsInsideFadeWindow() {
+        val clock = ControllableSleepTimerClock()
+        val player = RecordingMediaPlaybackController()
+        val playbackState = MutableStateFlow(
+            PlaybackState(
+                music = music("track-1"),
+                playingStatus = PlayingStatus.PLAYING,
+                position = 7_600L,
+                duration = 10_000L,
+                volume = 0.5f,
+            )
+        )
+        val controller = controller(
+            clock = clock,
+            player = player,
+            playbackState = playbackState,
+        )
+
+        controller.startUntilCurrentTrackEnd()
+        clock.advanceUntilIdle()
+
+        assertEquals(1, player.pauseCalls)
+        assertEquals(0.5f, player.volumeCalls.last())
+        assertEquals(SleepTimerState(), controller.state.value)
+    }
+
+    @Test
+    fun currentTrackEndTimerCancelsWhenThereIsNoCurrentMusic() {
+        val clock = ControllableSleepTimerClock()
+        val player = RecordingMediaPlaybackController()
+        val controller = controller(
+            clock = clock,
+            player = player,
+        )
+
+        controller.startUntilCurrentTrackEnd()
+
+        assertEquals(0, player.pauseCalls)
+        assertEquals(SleepTimerState(), controller.state.value)
+    }
+
+    private fun controller(
+        clock: SleepTimerClock,
+        player: RecordingMediaPlaybackController = RecordingMediaPlaybackController(),
+        playbackState: MutableStateFlow<PlaybackState> = MutableStateFlow(PlaybackState()),
+    ) = DefaultSleepTimerController(
+        mediaPlaybackController = player,
+        playbackState = playbackState,
+        scope = scope,
+        timerClock = clock,
+    )
+
+    private fun music(id: String) = Music(
+        id = id,
+        uri = "https://example.com/$id.mp3",
+    )
+}
+
+private class ControllableSleepTimerClock : SleepTimerClock {
+    private var nowMs = 0L
+    private val pendingDelays = mutableListOf<PendingDelay>()
+
+    override fun markNow(): SleepTimerMark {
+        val startMs = nowMs
+        return object : SleepTimerMark {
+            override fun elapsedMs(): Long = nowMs - startMs
+        }
+    }
+
+    override suspend fun delay(durationMs: Long) {
+        if (durationMs <= 0L) return
+
+        suspendCancellableCoroutine { continuation ->
+            val pendingDelay = PendingDelay(
+                targetMs = nowMs + durationMs,
+                continuation = continuation,
+            )
+            pendingDelays += pendingDelay
+            continuation.invokeOnCancellation {
+                pendingDelays.remove(pendingDelay)
+            }
+        }
+    }
+
+    fun advanceBy(durationMs: Long) {
+        nowMs += durationMs
+        resumeDueDelays()
+    }
+
+    fun advanceUntilIdle() {
+        var steps = 0
+        while (pendingDelays.isNotEmpty()) {
+            check(steps++ < MAX_ADVANCE_STEPS) {
+                "Too many pending sleep timer delays"
+            }
+            nowMs = pendingDelays.minOf { it.targetMs }
+            resumeDueDelays()
+        }
+    }
+
+    private fun resumeDueDelays() {
+        while (true) {
+            val dueDelays = pendingDelays
+                .filter { it.targetMs <= nowMs }
+                .sortedBy { it.targetMs }
+            if (dueDelays.isEmpty()) return
+
+            pendingDelays.removeAll(dueDelays)
+            dueDelays.forEach { delay ->
+                delay.continuation.resume(Unit)
+            }
+        }
+    }
+
+    private class PendingDelay(
+        val targetMs: Long,
+        val continuation: CancellableContinuation<Unit>,
+    )
+
+    private companion object {
+        const val MAX_ADVANCE_STEPS = 1_000
+    }
+}
+
+private class RecordingMediaPlaybackController : MediaPlaybackController {
+    var pauseCalls = 0
+        private set
+    val volumeCalls = mutableListOf<Float>()
+
+    override fun pause() {
+        pauseCalls++
+    }
+
+    override fun setVolume(volume: Float, androidFlags: Int) {
+        volumeCalls += volume
+    }
+
+    override fun seekTo(positionMs: Long) = Unit
+    override fun setRepeatMode(repeatMode: RepeatMode) = Unit
+    override fun setShuffleMode(isOn: Boolean) = Unit
+    override fun previous() = Unit
+    override fun next() = Unit
+    override fun play() = Unit
+    override fun moveMediaItem(currentIndex: Int, newIndex: Int) = Unit
+    override fun skipTo(musicIndex: Int) = Unit
+    override fun setSpeed(speed: Float) = Unit
+    override fun prepare(musics: List<Music>, index: Int, positionMs: Long) = Unit
+    override fun playMusics(musics: List<Music>, startIndex: Int) = Unit
+    override fun stop() = Unit
+    override fun appendMusics(musics: List<Music>) = Unit
+    override fun removeMusics(vararg musicId: String) = Unit
+    override fun replaceMusic(index: Int, music: Music) = Unit
+    override fun setMuted(muted: Boolean, androidFlags: Int) = Unit
+}

--- a/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.ios.kt
@@ -314,16 +314,39 @@ internal class PlatformMediaPlaybackController(
     }
 
     override fun removeMusics(vararg musicId: String) {
-        var nextMusic: Music? = null
+        var shouldStop = false
+        var replacementMusic: Music? = null
         musicId.forEach { id ->
-            nextMusic = playlistManager.removeMusic(id)
+            when (val result = playlistManager.removeMusicWithResult(id)) {
+                is PlaylistRemovalResult.RemovedCurrent -> {
+                    shouldStop = false
+                    replacementMusic = result.replacementMusic
+                }
+
+                PlaylistRemovalResult.PlaylistBecameEmpty -> {
+                    shouldStop = true
+                    replacementMusic = null
+                }
+
+                is PlaylistRemovalResult.RemovedNonCurrent,
+                PlaylistRemovalResult.NotFound -> Unit
+            }
         }
-        if (nextMusic != null) {
-            setMusic(nextMusic!!)
-        } else {
-            stop()
+        val musicToLoad = replacementMusic
+        when {
+            shouldStop -> {
+                stop()
+            }
+
+            musicToLoad != null -> {
+                setMusic(musicToLoad)
+                updatePlaybackState()
+            }
+
+            else -> {
+                updatePlaybackState()
+            }
         }
-        updatePlaybackState()
     }
 
     override fun replaceMusic(index: Int, music: Music) {

--- a/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/PlaylistManager.kt
+++ b/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/PlaylistManager.kt
@@ -2,130 +2,60 @@ package io.github.moonggae.kmedia.controller
 
 import io.github.moonggae.kmedia.model.Music
 import io.github.moonggae.kmedia.model.RepeatMode
-import io.github.moonggae.kmedia.util.reorder
 
-// Playlist Manager
 class PlaylistManager {
-    private val playlist = mutableListOf<Music>()
-    var currentIndex = 0
-        private set
-    private val shuffleManager = ShuffleManager()
+    private val state = PlaylistState()
 
-    var repeatMode = RepeatMode.REPEAT_MODE_OFF
-        private set
-    var isShuffleOn = false
-        private set
-
-    fun getCurrentMusic(): Music? = playlist.getOrNull(currentIndex)
-    fun getPlaylist(): List<Music> = playlist.toList()
-
-    fun updatePlaylist(musics: List<Music>, startIndex: Int) {
-        playlist.clear()
-        playlist.addAll(musics)
-        currentIndex = startIndex.coerceIn(0, playlist.lastIndex)
-        if (isShuffleOn) {
-            shuffleManager.updateShuffleIndices(currentIndex, playlist.size)
-        }
-    }
-
-    fun appendMusics(musics: List<Music>) {
-        val startIndex = playlist.size
-        val newMusics = musics - playlist.toSet()
-        playlist.addAll(newMusics)
-
-        if (isShuffleOn) {
-            shuffleManager.addNewIndices(startIndex, newMusics.size)
-        }
-    }
-
-    fun removeMusic(musicId: String): Music? {
-        val removeIndex = playlist.indexOfFirst { it.id == musicId }
-        if (removeIndex < 0) return null
-
-        val removedMusic = playlist[removeIndex]
-        val nextMusic = if (isShuffleOn) {
-            val nextShuffledIndex = shuffleManager.getNextIndex(currentIndex, repeatMode)
-                ?: shuffleManager.getPreviousIndex(currentIndex)
-            nextShuffledIndex?.let { playlist.getOrNull(it) }
-        } else {
-            playlist.getOrNull(removeIndex + 1) ?: playlist.getOrNull(removeIndex - 1)
+    var currentIndex: Int
+        get() = state.currentIndex
+        private set(value) {
+            state.setCurrentIndex(value)
         }
 
-        playlist.removeAt(removeIndex)
-
-        if (isShuffleOn) {
-            shuffleManager.removeIndex(removeIndex)
+    var repeatMode: RepeatMode
+        get() = state.repeatMode
+        private set(value) {
+            state.setRepeatMode(value)
         }
 
-        if (removeIndex == currentIndex) {
-            currentIndex = nextMusic?.let { playlist.indexOf(it) } ?: 0
-        } else if (removeIndex < currentIndex) {
-            currentIndex--
+    var isShuffleOn: Boolean
+        get() = state.isShuffleOn
+        private set(value) {
+            state.setShuffleMode(value)
         }
 
-        return nextMusic
+    fun getCurrentMusic(): Music? = state.getCurrentMusic()
+    fun getPlaylist(): List<Music> = state.getPlaylist()
+
+    fun updatePlaylist(musics: List<Music>, startIndex: Int) = state.updatePlaylist(musics, startIndex)
+
+    fun appendMusics(musics: List<Music>) = state.appendMusics(musics)
+
+    fun removeMusic(musicId: String): Music? = when (val result = removeMusicWithResult(musicId)) {
+        is PlaylistRemovalResult.RemovedCurrent -> result.replacementMusic
+        is PlaylistRemovalResult.RemovedNonCurrent,
+        PlaylistRemovalResult.NotFound,
+        PlaylistRemovalResult.PlaylistBecameEmpty -> null
     }
 
-    fun setShuffleMode(isOn: Boolean) {
-        if (this.isShuffleOn != isOn) {
-            this.isShuffleOn = isOn
-            if (isOn) {
-                shuffleManager.updateShuffleIndices(currentIndex, playlist.size)
-            }
-        }
-    }
+    internal fun removeMusicWithResult(musicId: String): PlaylistRemovalResult = state.removeMusic(musicId)
 
-    fun setRepeatMode(mode: RepeatMode) {
-        this.repeatMode = mode
-    }
+    fun setShuffleMode(isOn: Boolean) = state.setShuffleMode(isOn)
 
-    fun moveMediaItem(fromIndex: Int, toIndex: Int) {
-        val currentMusicId = playlist[currentIndex].id
-        playlist.reorder(fromIndex, toIndex)
-        currentIndex = playlist.indexOfFirst { it.id == currentMusicId }
-    }
+    fun setRepeatMode(mode: RepeatMode) = state.setRepeatMode(mode)
 
-    fun replaceMusic(index: Int, music: Music) {
-        if (index in 0..playlist.lastIndex) {
-            playlist[index] = music
-        }
-    }
+    fun moveMediaItem(fromIndex: Int, toIndex: Int) = state.moveMediaItem(fromIndex, toIndex)
 
-    fun getNextIndex(): Int? = when {
-        playlist.isEmpty() -> null
-        isShuffleOn -> shuffleManager.getNextIndex(currentIndex, repeatMode)
-        else -> when {
-            currentIndex == playlist.lastIndex &&
-                    repeatMode == RepeatMode.REPEAT_MODE_OFF -> null
-            currentIndex == playlist.lastIndex -> 0
-            else -> currentIndex + 1
-        }
-    }
+    fun replaceMusic(index: Int, music: Music) = state.replaceMusic(index, music)
 
-    fun getPreviousIndex(): Int? = when {
-        isShuffleOn -> shuffleManager.getPreviousIndex(currentIndex)
-        currentIndex > 0 -> currentIndex - 1
-        else -> null
-    }
+    fun getNextIndex(): Int? = state.getNextIndex()
 
-    fun setCurrentIndex(index: Int) {
-        if (index in 0..playlist.lastIndex) {
-            currentIndex = index
-        }
-    }
+    fun getPreviousIndex(): Int? = state.getPreviousIndex()
 
-    fun clear() {
-        playlist.clear()
-        currentIndex = 0
-        repeatMode = RepeatMode.REPEAT_MODE_OFF
-        isShuffleOn = false
-        shuffleManager.clear()
-    }
+    fun setCurrentIndex(index: Int) = state.setCurrentIndex(index)
 
-    fun hasNext(): Boolean = when {
-        isShuffleOn -> currentIndex < playlist.lastIndex
-        else -> currentIndex < playlist.lastIndex
-    } || repeatMode == RepeatMode.REPEAT_MODE_ALL
+    fun clear() = state.clear()
 
-    fun hasPrevious(): Boolean = currentIndex > 0
+    fun hasNext(): Boolean = state.hasNext()
+    fun hasPrevious(): Boolean = state.hasPrevious()
 }

--- a/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/ShuffleManager.kt
+++ b/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/ShuffleManager.kt
@@ -1,54 +1,21 @@
 package io.github.moonggae.kmedia.controller
 
 import io.github.moonggae.kmedia.model.RepeatMode
-import kotlin.experimental.ExperimentalNativeApi
 
-// Shuffle Manager
 class ShuffleManager {
-    private var shuffledIndices = mutableListOf<Int>()
+    private val order = ShuffleOrder()
 
-    fun updateShuffleIndices(currentIndex: Int, totalSize: Int) {
-        val remainingIndices = (0 until totalSize)
-            .filter { it != currentIndex }
-            .toMutableList()
-        remainingIndices.shuffle()
+    fun updateShuffleIndices(currentIndex: Int, totalSize: Int) =
+        order.updateShuffleIndices(currentIndex, totalSize)
 
-        shuffledIndices = mutableListOf(currentIndex).apply {
-            addAll(remainingIndices)
-        }
-    }
+    fun getNextIndex(currentIndex: Int, repeatMode: RepeatMode): Int? =
+        order.getNextIndex(currentIndex, repeatMode)
 
-    fun getNextIndex(currentIndex: Int, repeatMode: RepeatMode): Int? {
-        val currentShuffledIndex = shuffledIndices.indexOf(currentIndex)
-        return when {
-            currentShuffledIndex == shuffledIndices.lastIndex &&
-                    repeatMode == RepeatMode.REPEAT_MODE_OFF -> null
-            currentShuffledIndex == shuffledIndices.lastIndex ->
-                shuffledIndices.firstOrNull()
-            else -> shuffledIndices.getOrNull(currentShuffledIndex + 1)
-        }
-    }
+    fun getPreviousIndex(currentIndex: Int): Int? = order.getPreviousIndex(currentIndex)
 
-    fun getPreviousIndex(currentIndex: Int): Int? {
-        val currentShuffledIndex = shuffledIndices.indexOf(currentIndex)
-        return if (currentShuffledIndex > 0) {
-            shuffledIndices[currentShuffledIndex - 1]
-        } else null
-    }
+    fun removeIndex(index: Int) = order.removeIndex(index)
 
-    @OptIn(ExperimentalNativeApi::class)
-    fun removeIndex(index: Int) {
-        shuffledIndices.remove(index)
-        shuffledIndices.replaceAll { if (it > index) it - 1 else it }
-    }
+    fun clear() = order.clear()
 
-    fun clear() {
-        shuffledIndices.clear()
-    }
-
-    fun addNewIndices(startIndex: Int, count: Int) {
-        val newIndices = (startIndex until startIndex + count).toMutableList()
-        newIndices.shuffle()
-        shuffledIndices.addAll(newIndices)
-    }
+    fun addNewIndices(startIndex: Int, count: Int) = order.addNewIndices(startIndex, count)
 }


### PR DESCRIPTION
## Summary

- Extract playlist and shuffle behavior into common, testable state objects.
- Fix iOS removal handling so deleting a non-current item preserves the current track.
- Make the sleep timer testable with an internal clock abstraction and deterministic tests.
- Extract Android playback command routing behind an internal command target and test command order plus volume scaling.
- Add a GitHub Actions workflow for shared KMP checks and Android shared target compilation.

## Validation

- `./gradlew :shared:check --console=plain`
- `ANDROID_HOME=/Users/choi/Library/Android/sdk ./gradlew :shared:compileAndroidMain --console=plain`
- `./gradlew :kmedia-sample-android:assembleDebug --console=plain`