### PR TITLE
Made PlaybackStateObserverManager idempotent:

### DIFF
--- a/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/session/PlaybackStateObserverManager.kt
+++ b/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/session/PlaybackStateObserverManager.kt
@@ -22,7 +22,7 @@ class PlaybackStateObserverManager(
     private val onPlaybackStateChanged: () -> Unit
 ) {
     private var timeControlStatusObserver = createTimeControlStatusObserver()
-
+    private var isObserving = false
     private fun createTimeControlStatusObserver() = object : NSObject(), NSKeyValueObservingProtocol {
         override fun observeValueForKeyPath(
             keyPath: String?,
@@ -46,18 +46,23 @@ class PlaybackStateObserverManager(
     }
 
     fun startObserving() {
+        if (isObserving) return
         player.addObserver(
             observer = timeControlStatusObserver,
             forKeyPath = "timeControlStatus",
             options = NSKeyValueObservingOptionNew,
             context = null
         )
+        isObserving = true
     }
 
     fun stopObserving() {
+        if (!isObserving) return
         player.removeObserver(
             observer = timeControlStatusObserver,
             forKeyPath = "timeControlStatus"
         )
+        isObserving = false
+        timeControlStatusObserver = createTimeControlStatusObserver()
     }
 }

--- a/shared/src/iosTest/kotlin/io/github/moonggae/kmedia/session/PlaybackStateObserverManagerTest.kt
+++ b/shared/src/iosTest/kotlin/io/github/moonggae/kmedia/session/PlaybackStateObserverManagerTest.kt
@@ -1,0 +1,32 @@
+package io.github.moonggae.kmedia.session
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import platform.AVFoundation.AVPlayer
+import kotlin.test.Test
+
+class PlaybackStateObserverManagerTest {
+    @Test
+    fun observingLifecycleIsIdempotentAcrossRestart() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val manager = PlaybackStateObserverManager(
+            player = AVPlayer(),
+            coroutineScope = scope,
+            onPlaybackStateChanged = {}
+        )
+
+        try {
+            manager.stopObserving()
+            manager.startObserving()
+            manager.startObserving()
+            manager.stopObserving()
+            manager.stopObserving()
+            manager.startObserving()
+            manager.stopObserving()
+        } finally {
+            scope.cancel()
+        }
+    }
+}


### PR DESCRIPTION
- startObserving() now no-ops if already observing.
- stopObserving() now no-ops if not observing. After removal, it resets the observer instance so the manager can be safely restarted.

to verify the behavior please have a look at this branch:
https://github.com/msusman1/KMedia/tree/develop-nav
i have added some destinations