### PR TITLE
fix: stop to clear playback session state

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ spmForKmp="1.9.2"
 agp = "9.0.1"
 kotlin = "2.3.21"
 androidx-activityCompose = "1.13.0"
+androidx-test = "1.7.0"
+androidx-test-ext-junit = "1.3.0"
 media3 = "1.10.1"
 kotlinx-coroutines = "1.11.0"
 koin = "4.2.1"
@@ -26,6 +28,8 @@ kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-co
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
 
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin"  }

--- a/kmedia-sample-android/build.gradle.kts
+++ b/kmedia-sample-android/build.gradle.kts
@@ -12,6 +12,7 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
         versionCode = 1
         versionName = "1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildFeatures {
@@ -40,4 +41,7 @@ dependencies {
     implementation(project(":shared"))
     implementation(project(":kmedia-sample"))
     implementation(libs.androidx.activity.compose)
+
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/kmedia-sample-android/src/androidTest/kotlin/io/github/moonggae/kmedia/sample/KMediaStopBehaviorTest.kt
+++ b/kmedia-sample-android/src/androidTest/kotlin/io/github/moonggae/kmedia/sample/KMediaStopBehaviorTest.kt
@@ -1,0 +1,86 @@
+package io.github.moonggae.kmedia.sample
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.moonggae.kmedia.KMedia
+import io.github.moonggae.kmedia.model.CURRENT_INDEX_UNSET
+import io.github.moonggae.kmedia.model.Music
+import io.github.moonggae.kmedia.model.PlaybackState
+import io.github.moonggae.kmedia.model.PlayingStatus
+import io.github.moonggae.kmedia.model.TIME_UNSET
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KMediaStopBehaviorTest {
+    @Test
+    fun stopClearsCurrentPlaybackAndPlayDoesNotResumeStoppedQueue() = runBlocking {
+        val kMedia = KMedia.create()
+
+        kMedia.player.stop()
+        kMedia.awaitPlaybackState { it.isEmptyIdle() }
+
+        kMedia.player.prepare(testMusics, index = 1, positionMs = 0)
+        kMedia.awaitPlaybackState { state ->
+            state.music?.id == secondMusicId && state.currentIndex == 1
+        }
+
+        kMedia.player.stop()
+        val stoppedState = kMedia.awaitPlaybackState { it.isEmptyIdle() }
+        stoppedState.assertEmptyIdle()
+
+        kMedia.player.play()
+        delay(1_000)
+
+        kMedia.playbackState.value.assertEmptyIdle()
+    }
+
+    private suspend fun KMedia.awaitPlaybackState(
+        predicate: (PlaybackState) -> Boolean,
+    ): PlaybackState = withTimeout(5_000) {
+        playbackState.first(predicate)
+    }
+
+    private fun PlaybackState.isEmptyIdle(): Boolean =
+        music == null &&
+            playingStatus == PlayingStatus.IDLE &&
+            currentIndex == CURRENT_INDEX_UNSET &&
+            position == TIME_UNSET &&
+            duration == TIME_UNSET
+
+    private fun PlaybackState.assertEmptyIdle() {
+        assertNull(music)
+        assertEquals(PlayingStatus.IDLE, playingStatus)
+        assertEquals(CURRENT_INDEX_UNSET, currentIndex)
+        assertFalse(hasPrevious)
+        assertFalse(hasNext)
+        assertEquals(TIME_UNSET, position)
+        assertEquals(TIME_UNSET, duration)
+    }
+
+    companion object {
+        private const val firstMusicId = "android-stop-test-1"
+        private const val secondMusicId = "android-stop-test-2"
+
+        private val testMusics = listOf(
+            Music(
+                id = firstMusicId,
+                title = "Stop test 1",
+                artist = "KMedia",
+                uri = "https://example.com/kmedia-stop-test-1.mp3",
+            ),
+            Music(
+                id = secondMusicId,
+                title = "Stop test 2",
+                artist = "KMedia",
+                uri = "https://example.com/kmedia-stop-test-2.mp3",
+            ),
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.android.kt
@@ -7,6 +7,7 @@ import androidx.media3.session.SessionToken
 import io.github.moonggae.kmedia.model.Music
 import io.github.moonggae.kmedia.model.RepeatMode
 import io.github.moonggae.kmedia.session.PlaybackService
+import io.github.moonggae.kmedia.session.PlaybackResumeStore
 import io.github.moonggae.kmedia.util.asMediaItem
 import io.github.moonggae.kmedia.util.getMediaItemIndex
 import io.github.moonggae.kmedia.util.mediaItems
@@ -19,6 +20,7 @@ import kotlinx.coroutines.guava.asDeferred
 
 internal class PlatformMediaPlaybackController(
     private val context: Context,
+    private val playbackResumeStore: PlaybackResumeStore,
 ) : MediaPlaybackController, MediaPlaybackControllerReleaser {
     private var controllerDeferred: Deferred<MediaController> = newControllerAsync()
 
@@ -31,7 +33,12 @@ internal class PlatformMediaPlaybackController(
         CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private val commandController = ScopedMediaPlaybackCommandController(
-        targetProvider = { AndroidMediaPlaybackCommandTarget(activeControllerDeferred.await()) },
+        targetProvider = {
+            AndroidMediaPlaybackCommandTarget(
+                controller = activeControllerDeferred.await(),
+                playbackResumeStore = playbackResumeStore,
+            )
+        },
         scope = scope,
     )
 
@@ -94,6 +101,7 @@ internal class PlatformMediaPlaybackController(
 
 private class AndroidMediaPlaybackCommandTarget(
     private val controller: MediaController,
+    private val playbackResumeStore: PlaybackResumeStore,
 ) : MediaPlaybackCommandTarget {
     override suspend fun seekTo(positionMs: Long) {
         controller.seekTo(positionMs)
@@ -136,6 +144,7 @@ private class AndroidMediaPlaybackCommandTarget(
     }
 
     override suspend fun prepare(musics: List<Music>, index: Int, positionMs: Long) {
+        playbackResumeStore.allowSaving()
         controller.setMediaItems(musics.map { it.asMediaItem() }, index, positionMs)
         controller.prepare()
     }
@@ -145,6 +154,7 @@ private class AndroidMediaPlaybackCommandTarget(
     }
 
     override suspend fun appendMusics(musics: List<Music>) {
+        playbackResumeStore.allowSaving()
         controller.addMediaItems(musics.map { it.asMediaItem() })
     }
 
@@ -176,6 +186,7 @@ private class AndroidMediaPlaybackCommandTarget(
     }
 
     override suspend fun clearMediaItems() {
+        playbackResumeStore.clearForExplicitStop()
         controller.clearMediaItems()
     }
 

--- a/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/listener/PlaybackStateHandler.kt
+++ b/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/listener/PlaybackStateHandler.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.Timeline
 import io.github.moonggae.kmedia.model.PlaybackState
 import io.github.moonggae.kmedia.model.PlayingStatus
 import io.github.moonggae.kmedia.model.RepeatMode
+import io.github.moonggae.kmedia.model.emptyPlaybackState
 import io.github.moonggae.kmedia.session.PlaybackResumeStore
 import io.github.moonggae.kmedia.state.PlaybackStateManager
 import io.github.moonggae.kmedia.util.asMusic
@@ -96,8 +97,14 @@ internal class PlaybackStateHandler(
     }
 
     private fun updatePlayState() {
+        val currentMediaItem = player.currentMediaItem
+        if (currentMediaItem == null) {
+            playbackStateManager.playbackState = currentEmptyPlaybackState()
+            return
+        }
+
         playbackStateManager.playbackState = PlaybackState(
-            music = player.currentMediaItem?.asMusic(),
+            music = currentMediaItem.asMusic(),
             playingStatus = player.playingStatus,
             currentIndex = player.currentMediaItemIndex,
             hasPrevious = player.hasPreviousMediaItem(),
@@ -111,6 +118,11 @@ internal class PlaybackStateHandler(
         )
         playbackResumeStore.save(player)
     }
+
+    private fun currentEmptyPlaybackState() = emptyPlaybackState(
+        isMuted = player.isDeviceMuted,
+        volume = player.normalizedVolume
+    )
 }
 
 private val Player.normalizedVolume: Float

--- a/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/session/PlaybackResumeStore.kt
+++ b/shared/src/androidMain/kotlin/io/github/moonggae/kmedia/session/PlaybackResumeStore.kt
@@ -18,8 +18,11 @@ internal class PlaybackResumeStore(
     private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private var lastSavedSnapshot: PlaybackResumeSnapshot? = null
     private var lastSavedElapsedMs: Long = 0L
+    private var savingSuppressed = false
 
     fun save(player: Player, force: Boolean = false) {
+        if (savingSuppressed) return
+
         if (player.hasProtectedMediaItems()) {
             clear()
             return
@@ -48,6 +51,20 @@ internal class PlaybackResumeStore(
     }
 
     fun clear() {
+        clearSnapshot()
+        savingSuppressed = false
+    }
+
+    fun clearForExplicitStop() {
+        clearSnapshot()
+        savingSuppressed = true
+    }
+
+    fun allowSaving() {
+        savingSuppressed = false
+    }
+
+    private fun clearSnapshot() {
         prefs.edit().remove(KEY_SNAPSHOT).apply()
         lastSavedSnapshot = null
         lastSavedElapsedMs = 0L

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandController.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandController.kt
@@ -4,11 +4,15 @@ import io.github.moonggae.kmedia.model.Music
 import io.github.moonggae.kmedia.model.RepeatMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 internal class ScopedMediaPlaybackCommandController(
     private val targetProvider: suspend () -> MediaPlaybackCommandTarget,
     private val scope: CoroutineScope,
 ) : MediaPlaybackController, MediaPlaybackControllerReleaser {
+    private val commandMutex = Mutex()
+
     override fun seekTo(positionMs: Long) = execute { target ->
         target.seekTo(positionMs)
     }
@@ -60,6 +64,7 @@ internal class ScopedMediaPlaybackCommandController(
 
     override fun stop() = execute { target ->
         target.stop()
+        target.clearMediaItems()
         target.release()
     }
 
@@ -91,7 +96,9 @@ internal class ScopedMediaPlaybackCommandController(
 
     private inline fun execute(crossinline action: suspend (MediaPlaybackCommandTarget) -> Unit) {
         scope.launch {
-            action(targetProvider())
+            commandMutex.withLock {
+                action(targetProvider())
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/model/PlaybackStateFactories.kt
+++ b/shared/src/commonMain/kotlin/io/github/moonggae/kmedia/model/PlaybackStateFactories.kt
@@ -1,0 +1,9 @@
+package io.github.moonggae.kmedia.model
+
+internal fun emptyPlaybackState(
+    isMuted: Boolean = false,
+    volume: Float = 0f,
+) = PlaybackState(
+    isMuted = isMuted,
+    volume = volume,
+)

--- a/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandControllerTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/controller/ScopedMediaPlaybackCommandControllerTest.kt
@@ -54,13 +54,13 @@ class ScopedMediaPlaybackCommandControllerTest {
     }
 
     @Test
-    fun stopStopsAndReleasesTarget() {
+    fun stopStopsClearsAndReleasesTarget() {
         val target = RecordingCommandTarget()
         val controller = controller(target)
 
         controller.stop()
 
-        assertEquals(listOf("stop", "release"), target.calls)
+        assertEquals(listOf("stop", "clearMediaItems", "release"), target.calls)
     }
 
     @Test
@@ -79,6 +79,17 @@ class ScopedMediaPlaybackCommandControllerTest {
         val controller = controller(target)
 
         controller.release()
+        controller.play()
+
+        assertEquals(listOf("stop", "clearMediaItems", "release", "play"), target.calls)
+    }
+
+    @Test
+    fun commandsCanRunAfterStop() {
+        val target = RecordingCommandTarget()
+        val controller = controller(target)
+
+        controller.stop()
         controller.play()
 
         assertEquals(listOf("stop", "clearMediaItems", "release", "play"), target.calls)

--- a/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/model/PlaybackStateFactoriesTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/moonggae/kmedia/model/PlaybackStateFactoriesTest.kt
@@ -1,0 +1,28 @@
+package io.github.moonggae.kmedia.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class PlaybackStateFactoriesTest {
+    @Test
+    fun emptyPlaybackStateKeepsOnlyDeviceAudioSettings() {
+        val state = emptyPlaybackState(
+            isMuted = true,
+            volume = 0.42f,
+        )
+
+        assertNull(state.music)
+        assertEquals(PlayingStatus.IDLE, state.playingStatus)
+        assertEquals(CURRENT_INDEX_UNSET, state.currentIndex)
+        assertFalse(state.hasPrevious)
+        assertFalse(state.hasNext)
+        assertEquals(TIME_UNSET, state.position)
+        assertEquals(TIME_UNSET, state.duration)
+        assertFalse(state.isShuffleOn)
+        assertEquals(RepeatMode.REPEAT_MODE_OFF, state.repeatMode)
+        assertEquals(true, state.isMuted)
+        assertEquals(0.42f, state.volume)
+    }
+}

--- a/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/IosPlayerStateManager.kt
+++ b/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/IosPlayerStateManager.kt
@@ -20,6 +20,7 @@ import platform.AVFoundation.muted
 import platform.AVFoundation.pause
 import platform.AVFoundation.play
 import platform.AVFoundation.rate
+import platform.AVFoundation.replaceCurrentItemWithPlayerItem
 import platform.AVFoundation.seekToTime
 import platform.AVFoundation.setMuted
 import platform.AVFoundation.timeControlStatus
@@ -64,8 +65,17 @@ class IosPlayerStateManager(coroutineScope: CoroutineScope) {
     fun stop() {
         player.pause()
         playbackTimeObserverManager.cleanup()
-        musicStatusObserverManager.cleanup()
         musicCompleteTimeObserverManager.cleanup()
+        clearCurrentItem()
+    }
+
+    fun clearCurrentItem() {
+        musicStatusObserverManager.cleanup()
+        player.replaceCurrentItemWithPlayerItem(null)
+    }
+
+    fun replaceCurrentItem(item: AVPlayerItem) {
+        player.replaceCurrentItemWithPlayerItem(item)
     }
 
     fun setPosition(positionMs: Long) {

--- a/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/moonggae/kmedia/controller/PlatformMediaPlaybackController.ios.kt
@@ -16,6 +16,7 @@ import io.github.moonggae.kmedia.model.Music
 import io.github.moonggae.kmedia.model.PlaybackState
 import io.github.moonggae.kmedia.model.PlayingStatus
 import io.github.moonggae.kmedia.model.RepeatMode
+import io.github.moonggae.kmedia.model.emptyPlaybackState
 import io.github.moonggae.kmedia.session.PlaybackStateObserverManager
 import io.github.moonggae.kmedia.state.PlaybackStateManager
 import io.github.moonggae.kmedia.util.sanitizedRequestHeaders
@@ -29,8 +30,6 @@ import platform.AVFoundation.AVKeyValueStatusLoaded
 import platform.AVFoundation.AVPlayerItem
 import platform.AVFoundation.AVURLAsset
 import platform.AVFoundation.AVURLAssetPreferPreciseDurationAndTimingKey
-import platform.AVFoundation.currentItem
-import platform.AVFoundation.replaceCurrentItemWithPlayerItem
 import platform.Foundation.NSURL
 
 @OptIn(ExperimentalForeignApi::class)
@@ -68,6 +67,7 @@ internal class PlatformMediaPlaybackController(
 
     private var isLoading = false
     private var initialized = false
+    private var playbackRequestVersion = 0
 
     override fun prepare(musics: List<Music>, index: Int, positionMs: Long) {
         if (initialized == false) {
@@ -90,35 +90,37 @@ internal class PlatformMediaPlaybackController(
     }
 
     private fun setMusic(music: Music, playImmediately: Boolean = true) {
+        val requestVersion = nextPlaybackRequestVersion()
         scope.launch {
+            if (!isActivePlaybackRequest(requestVersion)) return@launch
             prepareMusic()
-            playMusic(music, playImmediately)
+            if (!isActivePlaybackRequest(requestVersion)) return@launch
+            playMusic(music, playImmediately, requestVersion)
         }
     }
 
     private fun prepareMusic() {
         isLoading = true
-        updatePlaybackState()
         cleanupCurrentItem()
+        updatePlaybackState()
     }
 
     private fun cleanupCurrentItem() {
-        playerStateManager.player.replaceCurrentItemWithPlayerItem(null)
-        playerStateManager.player.currentItem?.let {
-            playerStateManager.cleanup()
-        }
+        playerStateManager.clearCurrentItem()
     }
 
-    private fun playMusic(music: Music, playImmediately: Boolean) {
+    private fun playMusic(music: Music, playImmediately: Boolean, requestVersion: Int) {
+        if (!isActivePlaybackRequest(requestVersion)) return
+
         val nsUrl = NSURL(string = music.uri)
         val streamingAsset = createStreamingAsset(nsUrl, music.requestHeaders)
 
         if (!cacheRepository.enableCache) {
-            prepareAndPlay(streamingAsset, music, playImmediately)
+            prepareAndPlay(streamingAsset, music, playImmediately, requestVersion)
             return
         }
 
-        handleCaching(nsUrl, streamingAsset, music, playImmediately)
+        handleCaching(nsUrl, streamingAsset, music, playImmediately, requestVersion)
     }
 
     private fun createStreamingAsset(
@@ -145,6 +147,7 @@ internal class PlatformMediaPlaybackController(
         streamingAsset: AVURLAsset,
         music: Music,
         playImmediately: Boolean,
+        requestVersion: Int,
     ) {
         cachingLoader.loadFileWithCaching(
             url = nsUrl,
@@ -152,7 +155,8 @@ internal class PlatformMediaPlaybackController(
             requestHeaders = music.requestHeaders,
             onCompleteCaching = { handleCachingComplete(music) }
         ) { asset ->
-            handleCachingResult(asset, streamingAsset, music, playImmediately)
+            if (!isActivePlaybackRequest(requestVersion)) return@loadFileWithCaching
+            handleCachingResult(asset, streamingAsset, music, playImmediately, requestVersion)
         }
     }
 
@@ -161,20 +165,24 @@ internal class PlatformMediaPlaybackController(
         streamingAsset: AVURLAsset,
         music: Music,
         playImmediately: Boolean,
+        requestVersion: Int,
     ) {
+        if (!isActivePlaybackRequest(requestVersion)) return
+
         if (asset == null) {
-            handleCachingFailure(streamingAsset, music, playImmediately)
+            handleCachingFailure(streamingAsset, music, playImmediately, requestVersion)
             return
         }
-        prepareAndPlay(asset, music, playImmediately)
+        prepareAndPlay(asset, music, playImmediately, requestVersion)
     }
 
     private fun handleCachingFailure(
         streamingAsset: AVURLAsset,
         music: Music,
         playImmediately: Boolean,
+        requestVersion: Int,
     ) {
-        prepareAndPlay(streamingAsset, music, playImmediately)
+        prepareAndPlay(streamingAsset, music, playImmediately, requestVersion)
         scope.launch(Dispatchers.IO) {
             cacheStatusStore.update(music.cacheKey, CacheStatus.NONE)
         }
@@ -192,24 +200,32 @@ internal class PlatformMediaPlaybackController(
         asset: AVURLAsset,
         music: Music,
         playImmediately: Boolean,
+        requestVersion: Int,
     ) {
         asset.loadValuesAsynchronouslyForKeys(keys = listOf("playable")) {
+            if (!isActivePlaybackRequest(requestVersion)) return@loadValuesAsynchronouslyForKeys
+
             if (asset.statusOfValueForKey("playable", null) == AVKeyValueStatusLoaded) {
                 val newItem = AVPlayerItem(asset)
 
-                playerStateManager.player.replaceCurrentItemWithPlayerItem(newItem)
+                playerStateManager.replaceCurrentItem(newItem)
                 analyticsManager.startTracking(music)
                 updatePlaybackState()
 
                 playerStateManager.setupMusicStatusObserver(
                     item = newItem,
-                    onReadyToPlay = {
+                    onReadyToPlay = onReady@{
+                        if (!isActivePlaybackRequest(requestVersion)) return@onReady
                         isLoading = false
                         if (playImmediately) {
                             playerStateManager.play()
                         }
                     },
-                    onPlaybackStateChanged = ::updatePlaybackState
+                    onPlaybackStateChanged = {
+                        if (isActivePlaybackRequest(requestVersion)) {
+                            updatePlaybackState()
+                        }
+                    }
                 )
             } else {
                 // fallback: 다음 곡으로
@@ -284,6 +300,7 @@ internal class PlatformMediaPlaybackController(
     }
 
     override fun stop() {
+        invalidatePlaybackRequests()
         analyticsManager.stopTracking()
         releaseController()
         updatePlaybackState()
@@ -301,9 +318,10 @@ internal class PlatformMediaPlaybackController(
     }
 
     private fun releaseController() {
-        playerStateManager.stop()
-        playlistManager.clear()
+        isLoading = false
         eventManager.stopObserving()
+        playlistManager.clear()
+        playerStateManager.stop()
         controlCenterManager.release()
         initialized = false
     }
@@ -374,10 +392,16 @@ internal class PlatformMediaPlaybackController(
     }
 
     private fun updatePlaybackState() {
+        val currentMusic = playlistManager.getCurrentMusic()
+        if (currentMusic == null) {
+            playbackStateManager.playbackState = currentEmptyPlaybackState()
+            return
+        }
+
         val currentSeconds = playerStateManager.getCurrentPosition()
         val durationSeconds = playerStateManager.getDuration()
         val state = PlaybackState(
-            music = playlistManager.getCurrentMusic(),
+            music = currentMusic,
             playingStatus = if (isLoading) PlayingStatus.BUFFERING else playerStateManager.currentPlaybackStatus,
             currentIndex = playlistManager.currentIndex,
             hasPrevious = playlistManager.hasPrevious(),
@@ -392,9 +416,25 @@ internal class PlatformMediaPlaybackController(
         playbackStateManager.playbackState = state
 
         // 현재 재생 중인 곡의 정보로 제어 센터 업데이트
-        playlistManager.getCurrentMusic()?.let { music ->
-            controlCenterManager.updatePlaybackState(music, state)
-        }
+        controlCenterManager.updatePlaybackState(currentMusic, state)
+    }
+
+    private fun currentEmptyPlaybackState() = emptyPlaybackState(
+        isMuted = playerStateManager.isMuted,
+        volume = playerStateManager.volume
+    )
+
+    private fun nextPlaybackRequestVersion(): Int {
+        playbackRequestVersion += 1
+        return playbackRequestVersion
+    }
+
+    private fun invalidatePlaybackRequests() {
+        playbackRequestVersion += 1
+    }
+
+    private fun isActivePlaybackRequest(requestVersion: Int): Boolean {
+        return requestVersion == playbackRequestVersion
     }
 }
 


### PR DESCRIPTION
## Summary
- Make stop/release clear the current playback session and publish empty IDLE state
- Prevent Android resume store from restoring a queue after explicit stop
- Guard iOS async playback callbacks after stop
- Add regression tests for stop behavior